### PR TITLE
Add login page and responsive sidebar with working add buttons

### DIFF
--- a/src/app/(shell)/layout.tsx
+++ b/src/app/(shell)/layout.tsx
@@ -1,19 +1,25 @@
-﻿import { Sidebar } from '@/components/Sidebar';
+import { Sidebar } from '@/components/Sidebar';
 import { Topbar } from '@/components/Topbar';
 import ClientBootstrap from '@/components/ClientBootstrap';
+import { useState } from 'react';
 
 export default function ShellLayout({ children }: { children: React.ReactNode }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
   return (
     <div className="min-h-screen flex">
-      {/* Sidebar: always visible; sticky full height */}
-      <aside className="flex flex-col w-72 shrink-0 sticky top-0 h-screen p-6 border-r border-slate-200/70 bg-white/80 backdrop-blur-xl">
+      {/* Sidebar */}
+      <aside
+        className={`fixed inset-y-0 left-0 z-40 w-72 p-6 border-r border-slate-200/70 bg-white/80 backdrop-blur-xl flex flex-col transform transition-transform md:sticky md:translate-x-0 md:h-screen md:flex md:shrink-0 ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}`}
+      >
         <Sidebar />
       </aside>
+      {mobileOpen && <div className="fixed inset-0 z-30 bg-black/20 md:hidden" onClick={() => setMobileOpen(false)} />}
 
       {/* Main column */}
-      <main className="flex-1 flex flex-col">
+      <main className="flex-1 flex flex-col md:ml-72">
         <header className="sticky top-0 z-30 bg-white/70 backdrop-blur-xl border-b border-slate-200/70">
-          <Topbar />
+          <Topbar onMenu={() => setMobileOpen(true)} />
         </header>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
           {children}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Spinner } from '@/components/shared/Spinner';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const signIn = () => {
+    setLoading(true);
+    setTimeout(() => {
+      router.push('/dashboard');
+    }, 1500);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-100 p-4">
+      <div className="glass p-8 w-full max-w-sm text-center space-y-6">
+        <h1 className="text-2xl font-bold">FleetOS</h1>
+        <button
+          onClick={signIn}
+          className="w-full bg-brand text-white font-semibold py-2.5 rounded-xl shadow-soft hover:brightness-95 transition"
+        >
+          Sign In
+        </button>
+      </div>
+      {loading && (
+        <div className="fixed inset-0 flex items-center justify-center bg-white/80 backdrop-blur-sm">
+          <Spinner className="w-16 h-16" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,5 +2,5 @@
 import { redirect } from 'next/navigation';
 
 export default function Index() {
-  redirect('/dashboard');
+  redirect('/login');
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,10 +4,15 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useStore } from '@/lib/store';
 import { IoCubeOutline, IoCarOutline, IoNavigateOutline, IoFlameOutline, IoConstructOutline, IoPeopleOutline, IoAnalyticsOutline, IoSettingsOutline, IoSpeedometerOutline } from 'react-icons/io5';
+import { useState } from 'react';
+import { AddVehicleModal } from '@/components/modals/AddVehicleModal';
+import { AddUserModal } from '@/components/modals/AddUserModal';
 
 export function Sidebar() {
   const pathname = usePathname();
   const { vehicles } = useStore();
+  const [vehicleOpen, setVehicleOpen] = useState(false);
+  const [userOpen, setUserOpen] = useState(false);
 
   const link = (href:string, label:string, icon:React.ReactNode) => {
     const active = pathname.startsWith(href);
@@ -50,9 +55,22 @@ export function Sidebar() {
           </div>
           <div className="text-sm text-slate-600">{vehicles.length} Vehicles • {online} Online</div>
         </div>
-        <button className="w-full bg-brand text-white font-semibold py-2.5 rounded-xl shadow-soft hover:brightness-95 transition">Add Vehicle</button>
-        <button className="w-full bg-slate-900 text-white font-semibold py-2.5 rounded-xl shadow-soft hover:brightness-95 transition">Add User</button>
+        <button
+          className="w-full bg-brand text-white font-semibold py-2.5 rounded-xl shadow-soft hover:brightness-95 transition"
+          onClick={() => setVehicleOpen(true)}
+        >
+          Add Vehicle
+        </button>
+        <button
+          className="w-full bg-slate-900 text-white font-semibold py-2.5 rounded-xl shadow-soft hover:brightness-95 transition"
+          onClick={() => setUserOpen(true)}
+        >
+          Add User
+        </button>
       </div>
+
+      <AddVehicleModal open={vehicleOpen} onClose={() => setVehicleOpen(false)} />
+      <AddUserModal open={userOpen} onClose={() => setUserOpen(false)} />
     </>
   );
 }

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from 'react';
 import { useStore } from '@/lib/store';
-import { IoNotificationsOutline, IoSearchOutline, IoRefreshOutline, IoPersonCircleOutline } from 'react-icons/io5';
+import { IoNotificationsOutline, IoSearchOutline, IoRefreshOutline, IoPersonCircleOutline, IoMenu } from 'react-icons/io5';
 
-export function Topbar() {
+export function Topbar({ onMenu }: { onMenu?: () => void }) {
   const { setSearch, liveData, setLiveData } = useStore();
   const [range, setRange] = useState<'7'|'30'|'365'>('7');
 
@@ -12,6 +12,9 @@ export function Topbar() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6">
       <div className="h-16 flex items-center justify-between">
         <div className="flex items-center gap-3">
+          <button className="md:hidden" onClick={onMenu}>
+            <IoMenu className="text-2xl" />
+          </button>
           <div className="relative">
             <IoSearchOutline className="absolute left-3 top-2.5 text-slate-400" />
             <input onChange={(e)=>setSearch(e.target.value)} placeholder="Search vehicles, drivers, routes..." className="pl-10 pr-4 py-2 rounded-xl bg-slate-100 focus:bg-white border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 transition w-72" />

--- a/src/components/shared/Spinner.tsx
+++ b/src/components/shared/Spinner.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+export function Spinner({ className = '' }: { className?: string }) {
+  return (
+    <div className={`animate-spin rounded-full border-4 border-brand border-t-transparent ${className}`}></div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add dedicated login screen with spinner preloader routing to dashboard
- Introduce reusable spinner component
- Make sidebar mobile-friendly with toggle button in top bar
- Wire up Add Vehicle and Add User buttons to open their modals
- Redirect root path to login page

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68c539a240588329bba3fc73729056dc